### PR TITLE
Allow usage of lib

### DIFF
--- a/lib/makeup/lexers/erlang_lexer/application.ex
+++ b/lib/makeup/lexers/erlang_lexer/application.ex
@@ -1,0 +1,17 @@
+defmodule Makeup.Lexers.ErlangLexer.Application do
+  @moduledoc false
+  use Application
+
+  alias Makeup.Registry
+  alias Makeup.Lexers.ErlangLexer
+
+  def start(_type, _args) do
+    Registry.register_lexer(ErlangLexer,
+      options: [],
+      names: ["erlang", "erl"],
+      extensions: ["erl", "hrl", "escript"]
+    )
+
+    Supervisor.start_link([], strategy: :one_for_one)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,7 @@ defmodule MakeupErlang.Mixfile do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
+      mod: {Makeup.Lexers.ErlangLexer.Application, []},
       extra_applications: [:logger]
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,7 @@ defmodule MakeupErlang.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:makeup, "~> 0.8"},
+      {:makeup, "~> 1.0"},
       {:assert_value, "~> 0.9", only: [:dev, :test]},
       {:ex_doc, "~> 0.19.3", only: [:dev, :test]}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "assert_value": {:hex, :assert_value, "0.9.2", "8b6534737667212c880ebd2c241c48fc42359a90122ecee076e7433eb1eef8e9", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
 }

--- a/test/makeup/erlang_lexer/application_test.exs
+++ b/test/makeup/erlang_lexer/application_test.exs
@@ -1,0 +1,19 @@
+defmodule Makeup.Lexers.ErlangLexer.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  alias Makeup.Registry
+  alias Makeup.Lexers.ErlangLexer
+
+  describe "start/2" do
+    test "registers itself as an `makeup` lexer on application boot for `erlang` and `erl` language names" do
+      assert {:ok, {ErlangLexer, []}} == Registry.fetch_lexer_by_name("erlang")
+      assert {:ok, {ErlangLexer, []}} == Registry.fetch_lexer_by_name("erl")
+    end
+
+    test "registers itself as an `makeup` lexer on application boot for `erl`, `hrl` and `escript` file extensions" do
+      assert {:ok, {ErlangLexer, []}} == Registry.fetch_lexer_by_extension("erl")
+      assert {:ok, {ErlangLexer, []}} == Registry.fetch_lexer_by_extension("hrl")
+      assert {:ok, {ErlangLexer, []}} == Registry.fetch_lexer_by_extension("escript")
+    end
+  end
+end


### PR DESCRIPTION
Right now we can't "just include" the lib as a dependency to be able to use it (like the lib `makeup_elixir` does) and because of that we need to make some changes:

- Updates makeup version to ~> 1.0 in mix.exs
As to be able to use this lexer alongside `makeup_elixir` (it was conflicting).
Since I had to do a `mix deps.unlock makeup` it updated:
  - `makeup_elixir` from `0.13.0 to `0.14.0`
  - `nimble_parsec` from `0.5.0` to `0.5.1`.

- Register itself as a makeup lexer on application boot
To be able to use the lexer just by including it as a dependency.