### PR TITLE
Add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+sudo: false
+language: elixir
+
+elixir: '1.9'
+otp_release: '22.0'
+
+stages:
+  - test
+
+jobs:
+  include:
+    - stage: test
+
+    - elixir: 1.5
+      otp_release: 19.3
+    - elixir: 1.5
+      otp_release: 20.3
+    - elixir: 1.9
+      otp_release: 20.3
+    - elixir: 1.9
+      otp_release: 21.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,14 @@ elixir: '1.9'
 otp_release: '22.0'
 
 stages:
+  - check formatted
   - test
 
 jobs:
   include:
+    - stage: check formatted
+      script: mix format --check-formatted
+
     - stage: test
 
     - elixir: 1.5

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MakeupErlang
 
+[![Build Status](https://travis-ci.org/tmbb/makeup_erlang.svg?branch=master)](https://travis-ci.org/tmbb/makeup_erlang)
+
 Lexer for the Erlang language for Makeup.
 
 ## Installation

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -10,22 +10,24 @@ defmodule ErlangLexerTokenizer do
   test "comment" do
     assert lex("%abc") == [{:comment_single, %{}, "%abc"}]
     assert lex("% abc") == [{:comment_single, %{}, "% abc"}]
+
     assert lex("% abc\n") == [
-      {:comment_single, %{}, "% abc"},
-      {:whitespace, %{}, "\n"}
-    ]
+             {:comment_single, %{}, "% abc"},
+             {:whitespace, %{}, "\n"}
+           ]
+
     assert lex("% abc\n123") == [
-      {:comment_single, %{}, "% abc"},
-      {:whitespace, %{}, "\n"},
-      {:number_integer, %{}, "123"}
-    ]
+             {:comment_single, %{}, "% abc"},
+             {:whitespace, %{}, "\n"},
+             {:number_integer, %{}, "123"}
+           ]
   end
 
   test "namespace" do
     assert lex("mod:") == [
-      {:name_namespace, %{}, "mod"},
-      {:punctuation, %{}, ":"}
-    ]
+             {:name_namespace, %{}, "mod"},
+             {:punctuation, %{}, ":"}
+           ]
   end
 
   test "variable" do
@@ -37,26 +39,27 @@ defmodule ErlangLexerTokenizer do
 
   test "function call" do
     assert lex("f(") == [
-      {:name_function, %{}, "f"},
-      {:punctuation, %{group_id: "group-1"}, "("}
-    ]
+             {:name_function, %{}, "f"},
+             {:punctuation, %{group_id: "group-1"}, "("}
+           ]
+
     assert lex("f(1)") == [
-      {:name_function, %{}, "f"},
-      {:punctuation, %{group_id: "group-1"}, "("},
-      {:number_integer, %{}, "1"},
-      {:punctuation, %{group_id: "group-1"}, ")"}
-    ]
+             {:name_function, %{}, "f"},
+             {:punctuation, %{group_id: "group-1"}, "("},
+             {:number_integer, %{}, "1"},
+             {:punctuation, %{group_id: "group-1"}, ")"}
+           ]
   end
 
   test "qualified function call" do
     assert lex("mod:f(1)") == [
-      {:name_namespace, %{}, "mod"},
-      {:punctuation, %{}, ":"},
-      {:name_function, %{}, "f"},
-      {:punctuation, %{group_id: "group-1"}, "("},
-      {:number_integer, %{}, "1"},
-      {:punctuation, %{group_id: "group-1"}, ")"}
-    ]
+             {:name_namespace, %{}, "mod"},
+             {:punctuation, %{}, ":"},
+             {:name_function, %{}, "f"},
+             {:punctuation, %{group_id: "group-1"}, "("},
+             {:number_integer, %{}, "1"},
+             {:punctuation, %{group_id: "group-1"}, ")"}
+           ]
   end
 
   describe "numbers" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start([timeout: :infinity])
+ExUnit.start(timeout: :infinity)


### PR DESCRIPTION
### Implementation

- Adds a `travis.yml`
- Adds the README badge showing the status of the master branch
- Run formatter in the codebase so we are able to check for it on CI (can be a separated PR if needed)

### Additional things :warning:

I couldn't test against `elixir` `1.4` because the `ex_doc` dependency was erroring out at compile time so I went with the nearest version that was `1.5`. 

<details>
<summary> error </summary>

<img width="1436" alt="Screenshot 2019-08-15 15 36 12" src="https://user-images.githubusercontent.com/14015177/63117570-7a448a80-bf72-11e9-81bc-1990dc7789a2.png">
</details>

We will probably have to update our version requirement to at least `1.5` in [`mix.exs`](https://github.com/tmbb/makeup_erlang/blob/e1f4c28b355f56d55bd9dd806176a4d14ed47805/mix.exs#L8) soon since right now it does not work in `1.4`.

Not forgetting that we will have to enable the repository in https://travis-ci.org for it to build and test our branches/PRs.