### PR TITLE
Fix error when trying to lex text with the binary sintax in it

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -161,7 +161,7 @@ defmodule Makeup.Lexers.ErlangLexer do
   erlang_string = string_like("\"", "\"", [escape_token, string_interpol], :string)
 
   # Combinators that highlight expressions surrounded by a pair of delimiters.
-  punctuation = word_from_list(~w[\[ \] : _ @ \" . \#{ { } ( ) | ; , => :=], :punctuation)
+  punctuation = word_from_list(~w[\[ \] : _ @ \" . \#{ { } ( ) | ; , => := << >>], :punctuation)
 
   tuple = many_surrounded_by(parsec(:root_element), "{", "}")
 
@@ -192,9 +192,6 @@ defmodule Makeup.Lexers.ErlangLexer do
     token("\n-", :punctuation)
     |> choice([define, record, normal_directive])
 
-  # Should we merge these into the operators or punctuation?
-  binary_markers = choice([string("<<"), string(">>")])
-
   # Tag the tokens with the language name.
   # This makes it easier to postprocess files with multiple languages.
   @doc false
@@ -209,7 +206,6 @@ defmodule Makeup.Lexers.ErlangLexer do
       whitespace,
       comment,
       punctuation,
-      binary_markers,
       # `tuple` might be unnecessary
       tuple,
       operators,

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -1,6 +1,5 @@
 defmodule ErlangLexerTokenizer do
   use ExUnit.Case, async: false
-  import AssertValue
   import Makeup.Lexers.ErlangLexer.Testing, only: [lex: 1]
 
   test "empty string" do

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -83,4 +83,29 @@ defmodule ErlangLexerTokenizer do
       assert lex("1.05e-12") == [{:number_float, %{}, "1.05e-12"}]
     end
   end
+
+  describe "binary" do
+    test "<<>> syntax" do
+      assert lex(~s/<<>>/) == [{:punctuation, %{}, "<<"}, {:punctuation, %{}, ">>"}]
+    end
+
+    test "<<\"\">> syntax" do
+      assert lex(~s/<<"">>/) == [
+               {:punctuation, %{}, "<<"},
+               {:punctuation, %{}, "\""},
+               {:punctuation, %{}, "\""},
+               {:punctuation, %{}, ">>"}
+             ]
+    end
+
+    test "<<\"string\">> syntax" do
+      assert lex(~s/<<"string">>/) == [
+               {:punctuation, %{}, "<<"},
+               {:punctuation, %{}, "\""},
+               {:name_symbol, %{}, "string"},
+               {:punctuation, %{}, "\""},
+               {:punctuation, %{}, ">>"}
+             ]
+    end
+  end
 end


### PR DESCRIPTION
### Why?

Before this change, it was raising a `FunctionClauseError`
in the post process function `Makeup.Lexers.ErlangLexer.__as_erlang_language/1`
when trying to lex text with binary syntax in it (`<<` and `>>`).

```bash
iex(1)> Makeup.Lexers.ErlangLexer.Testing.lex("<<>>")
** (FunctionClauseError) no function clause matching in Makeup.Lexers.ErlangLexer.__as_erlang_language__/1

    The following arguments were given to Makeup.Lexers.ErlangLexer.__as_erlang_language__/1:

        # 1
        "<<"

    Attempted function clauses (showing 1 out of 1):

        def __as_erlang_language__({ttype, meta, value})

    (makeup_erlang) lib/makeup/lexers/erlang_lexer.ex:201: Makeup.Lexers.ErlangLexer.__as_erlang_language__/1
    (elixir) lib/enum.ex:1336: Enum."-map/2-lists^map/1-0-"/2
    (makeup_erlang) Makeup.Lexers.ErlangLexer.root_element__2/6
    (makeup_erlang) Makeup.Lexers.ErlangLexer.root__2/6
    (makeup_erlang) Makeup.Lexers.ErlangLexer.root/2
    (makeup_erlang) lib/makeup/lexers/erlang_lexer.ex:355: Makeup.Lexers.ErlangLexer.lex/2
    (makeup_erlang) lib/makeup/lexers/erlang_lexer/testing.ex:13: Makeup.Lexers.ErlangLexer.Testing.lex/1
```

### How?
It was erroring out because we were not wrapping the binary syntax
combinators with the `Makeup.Lexer.Combinators.token/2` combinator,
which returns the result that `__as_erlang_language/1` expects.

It was being passed a literal `"<<"` instead of the `token` tuple that is expected.
e.g. `{:token_name, attrs = %{}, literal = "<<"}`.

## Implementation
Just adding both `<<` and `>>` to the punctuation combinator made it work, since it was already being wrapped by the `token/2` combinator.

I'm just not that sure if it really belongs to the `punctuations` one, WDYT?
The comment that was there also raises the same question.