### PR TITLE
Improve atoms, operators and punctuations

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -161,17 +161,13 @@ defmodule Makeup.Lexers.ErlangLexer do
   erlang_string = string_like("\"", "\"", [escape_token, string_interpol], :string)
 
   # Combinators that highlight expressions surrounded by a pair of delimiters.
-  punctuation = word_from_list(~w[\[ \] : _ @ \" . \#{ { } ( ) | ; , => := << >>], :punctuation)
+  punctuation =
+    word_from_list(~w[\[ \] : _ @ \" . \#{ { } ( ) | ; , => := << >> || -> \#], :punctuation)
 
   tuple = many_surrounded_by(parsec(:root_element), "{", "}")
 
-  operators =
-    word_from_list(
-      ~W[
-      + +? -- * / < > /= =:= =/= <= >= ==? <- ! ?
-    ],
-      :operator
-    )
+  syntax_operators =
+    word_from_list(~W[+ - +? ++ = == -- * / < > /= =:= =/= =< >= ==? <- ! ? ?!], :operator)
 
   define =
     token("define", :name_entity)
@@ -208,7 +204,7 @@ defmodule Makeup.Lexers.ErlangLexer do
       punctuation,
       # `tuple` might be unnecessary
       tuple,
-      operators,
+      syntax_operators,
       # Numbers
       number_integer_in_weird_base,
       number_float,

--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -95,11 +95,11 @@ defmodule Makeup.Lexers.ErlangLexer do
   simple_atom_name =
     ascii_string([?a..?z], 1)
     |> optional(ascii_string([?a..?z, ?_, ?0..?9, ?A..?Z], min: 1))
+    |> reduce({Enum, :join, []})
 
   quoted_atom_name =
     string("'")
-    |> optional(utf8_string([not: ?\n, not: ?'], min: 1))
-    |> utf8_string([not: ?\\], min: 1)
+    |> optional(utf8_string([not: ?\n, not: ?', not: ?\\], min: 1))
     |> string("'")
 
   atom_name =
@@ -108,7 +108,7 @@ defmodule Makeup.Lexers.ErlangLexer do
       quoted_atom_name
     ])
 
-  atom = token(atom_name, :name_symbol)
+  atom = token(atom_name, :string_symbol)
 
   namespace =
     token(atom_name, :name_namespace)
@@ -282,13 +282,13 @@ defmodule Makeup.Lexers.ErlangLexer do
 
   @word_operators ~W[and andalso band bnot bor bsl bsr bxor div not or orelse rem xor]
 
-  defp postprocess_helper([{:name, meta, value} | tokens]) when value in @keywords,
+  defp postprocess_helper([{:string_symbol, meta, value} | tokens]) when value in @keywords,
     do: [{:keyword, meta, value} | postprocess_helper(tokens)]
 
-  defp postprocess_helper([{:name, meta, value} | tokens]) when value in @builtins,
+  defp postprocess_helper([{:string_symbol, meta, value} | tokens]) when value in @builtins,
     do: [{:name_builtin, meta, value} | postprocess_helper(tokens)]
 
-  defp postprocess_helper([{:name, meta, value} | tokens]) when value in @word_operators,
+  defp postprocess_helper([{:string_symbol, meta, value} | tokens]) when value in @word_operators,
     do: [{:operator_word, meta, value} | postprocess_helper(tokens)]
 
   defp postprocess_helper([token | tokens]), do: [token | postprocess_helper(tokens)]

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -156,6 +156,26 @@ defmodule ErlangLexerTokenizer do
   end
 
   describe "operators" do
+    test "syntax operators are tokenized as operator" do
+      assert lex("+") == [{:operator, %{}, "+"}]
+      assert lex("-") == [{:operator, %{}, "-"}]
+      assert lex("*") == [{:operator, %{}, "*"}]
+      assert lex("/") == [{:operator, %{}, "/"}]
+      assert lex("==") == [{:operator, %{}, "=="}]
+      assert lex("/=") == [{:operator, %{}, "/="}]
+      assert lex("=:=") == [{:operator, %{}, "=:="}]
+      assert lex("=/=") == [{:operator, %{}, "=/="}]
+      assert lex("<") == [{:operator, %{}, "<"}]
+      assert lex("=<") == [{:operator, %{}, "=<"}]
+      assert lex(">") == [{:operator, %{}, ">"}]
+      assert lex(">=") == [{:operator, %{}, ">="}]
+      assert lex("++") == [{:operator, %{}, "++"}]
+      assert lex("--") == [{:operator, %{}, "--"}]
+      assert lex("=") == [{:operator, %{}, "="}]
+      assert lex("!") == [{:operator, %{}, "!"}]
+      assert lex("<-") == [{:operator, %{}, "<-"}]
+    end
+
     test "word operators are tokenized as operator" do
       assert lex("div") == [{:operator_word, %{}, "div"}]
       assert lex("rem") == [{:operator_word, %{}, "rem"}]

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -101,10 +101,92 @@ defmodule ErlangLexerTokenizer do
       assert lex(~s/<<"string">>/) == [
                {:punctuation, %{}, "<<"},
                {:punctuation, %{}, "\""},
-               {:name_symbol, %{}, "string"},
+               {:string_symbol, %{}, "string"},
                {:punctuation, %{}, "\""},
                {:punctuation, %{}, ">>"}
              ]
+    end
+  end
+
+  describe "atoms" do
+    test "are tokenized as such" do
+      assert lex("atom") == [{:string_symbol, %{}, "atom"}]
+    end
+
+    test "are tokenized as such even when quoted" do
+      assert lex("'atom'") == [{:string_symbol, %{}, "'atom'"}]
+      assert lex("'atom atom'") == [{:string_symbol, %{}, "'atom atom'"}]
+      assert lex("'atom+atom'") == [{:string_symbol, %{}, "'atom+atom'"}]
+      assert lex("'atom@atom'") == [{:string_symbol, %{}, "'atom@atom'"}]
+      assert lex("'atom123atom'") == [{:string_symbol, %{}, "'atom123atom'"}]
+    end
+
+    test "does not tokenize invalid characters as atom (\\n, ', \\)" do
+      assert {:string_symbol, %{}, "atom"} in lex("atom\n")
+      assert {:string_symbol, %{}, "atom"} in lex("atom'")
+      assert {:string_symbol, %{}, "atom"} in lex("atom\\")
+    end
+  end
+
+  describe "keywords" do
+    test "keyword is tokenized as keyword" do
+      assert lex("after") == [{:keyword, %{}, "after"}]
+      assert lex("begin") == [{:keyword, %{}, "begin"}]
+      assert lex("case") == [{:keyword, %{}, "case"}]
+      assert lex("catch") == [{:keyword, %{}, "catch"}]
+      assert lex("cond") == [{:keyword, %{}, "cond"}]
+      assert lex("end") == [{:keyword, %{}, "end"}]
+      assert lex("fun") == [{:keyword, %{}, "fun"}]
+      assert lex("if") == [{:keyword, %{}, "if"}]
+      assert lex("of") == [{:keyword, %{}, "of"}]
+      assert lex("query") == [{:keyword, %{}, "query"}]
+      assert lex("receive") == [{:keyword, %{}, "receive"}]
+      assert lex("when") == [{:keyword, %{}, "when"}]
+    end
+
+    test "atoms are not tokenized as keyword" do
+      refute lex("literal_atom") == [{:keyword, %{}, "literal_atom"}]
+    end
+
+    test "atoms that include a keyword on it is not tokenized as keyword" do
+      refute {:keyword, %{}, "fun"} in lex("func")
+      refute {:keyword, %{}, "when"} in lex("when_found")
+      refute {:keyword, %{}, "when"} in lex("found_when")
+    end
+  end
+
+  describe "operators" do
+    test "word operators are tokenized as operator" do
+      assert lex("div") == [{:operator_word, %{}, "div"}]
+      assert lex("rem") == [{:operator_word, %{}, "rem"}]
+      assert lex("or") == [{:operator_word, %{}, "or"}]
+      assert lex("xor") == [{:operator_word, %{}, "xor"}]
+      assert lex("bor") == [{:operator_word, %{}, "bor"}]
+      assert lex("bxor") == [{:operator_word, %{}, "bxor"}]
+      assert lex("bsl") == [{:operator_word, %{}, "bsl"}]
+      assert lex("bsr") == [{:operator_word, %{}, "bsr"}]
+      assert lex("and") == [{:operator_word, %{}, "and"}]
+      assert lex("band") == [{:operator_word, %{}, "band"}]
+      assert lex("not") == [{:operator_word, %{}, "not"}]
+      assert lex("bnot") == [{:operator_word, %{}, "bnot"}]
+    end
+
+    test "atoms are not tokenized as operator" do
+      refute lex("literal_atom") == [{:operator_word, %{}, "literal_atom"}]
+    end
+
+    test "atoms that includes operators are not tokenized as operator" do
+      refute {:operator_word, %{}, "div"} in lex("divatom")
+      refute {:operator_word, %{}, "div"} in lex("div_atom")
+      refute {:operator_word, %{}, "div"} in lex("atom_div")
+      refute {:operator_word, %{}, "div"} in lex("atomdiv")
+      refute {:operator_word, %{}, "div"} in lex("atomdivatom")
+      refute {:operator_word, %{}, "div"} in lex("'div'")
+      refute {:operator_word, %{}, "+"} in lex("'quoted + atom'")
+    end
+
+    test "string that includes operators are not tokenized as operator" do
+      refute {:word_operator, %{}, "div"} in lex(~s/"div"/)
     end
   end
 end


### PR DESCRIPTION
Improve some of the combinators as to give better tokens thus better highlight results.

I tried to explain the _whys_ on the commit messages but if they are not that clear ping me so I can come up with a better description for this PR. 😄

<details>
<summary> Before </summary>
<img width="304" alt="Screenshot 2019-09-06 16 16 50" src="https://user-images.githubusercontent.com/14015177/64455407-f8083b80-d0c3-11e9-9b54-ca5033ec7e77.png">
<img width="436" alt="Screenshot 2019-09-06 16 17 09" src="https://user-images.githubusercontent.com/14015177/64455643-93011580-d0c4-11e9-965d-80a58b459023.png">
</details>

<details>
<summary> After </summary>
<img width="309" alt="Screenshot 2019-09-06 16 17 00" src="https://user-images.githubusercontent.com/14015177/64455411-fb9bc280-d0c3-11e9-9903-961d809ac993.png">
<img width="419" alt="Screenshot 2019-09-06 16 17 18" src="https://user-images.githubusercontent.com/14015177/64455646-94cad900-d0c4-11e9-9be3-6f7d86184226.png">
</details>

Things that I already mapped and we will have to do (but I was thinking about doing it in other PRs, wdyt?):

- Fix the combinator for strings for some cases (for example, the `"V +"` is being tokenized as something like `[:punctuation, :variable, :whitespace, :operator]`) and it should be a single unit
- Fix the combinator for the interpolation characters, that as far as I can tell are not being tokenized at all
- Add the string token to the binary combinator (`<< >>`)
- Fix the combinator for module attributes (e.g. `-module`, `-import`)
- The overall combianators organization, maybe split some into smaller units and compose from there? (for example, have a `erlang_letter = ascii_char([?A..?Z, ?a..?z)` and compose it on larger combinators)
- Have some kind of pattern for what is a final `token` combinator and what can be composed

But that can be discussed waaaay later. 😄

I've been based all my changes on the _"semi-official"_ [erlang/spec](https://github.com/erlang/spec), mostly the Grammar Appendix.