### PR TITLE
Improve charlist combinator

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -50,8 +50,6 @@ defmodule Makeup.Lexers.ErlangLexer do
       escape_ctrl
     ])
 
-  escape_token = token(escape, :string_escape)
-
   numeric_base =
     choice([
       ascii_char([?1..?2]) |> ascii_char([?0..?9]),
@@ -158,7 +156,7 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> ascii_char(to_charlist("~#+BPWXb-ginpswx"))
     |> token(:string_interpol)
 
-  erlang_string = string_like("\"", "\"", [escape_token, string_interpol], :string)
+  erlang_string = string_like("\"", "\"", [string_interpol], :string)
 
   # Combinators that highlight expressions surrounded by a pair of delimiters.
   punctuation =
@@ -201,6 +199,7 @@ defmodule Makeup.Lexers.ErlangLexer do
       hashbang,
       whitespace,
       comment,
+      erlang_string,
       punctuation,
       # `tuple` might be unnecessary
       tuple,
@@ -211,7 +210,6 @@ defmodule Makeup.Lexers.ErlangLexer do
       number_integer,
       # Variables
       variable,
-      erlang_string,
       namespace,
       function,
       atom,


### PR DESCRIPTION
Tried to explain what was done in the commit messages, if it's not that clear please ping so I update this PR description. 😄

<details>
<summary> Before </summary>
<img src="https://user-images.githubusercontent.com/14015177/66157251-c7032400-e5f9-11e9-86db-78c0c71a8801.png">

</details>

<details>
<summary> After </summary>
<img src="https://user-images.githubusercontent.com/14015177/66157259-c9657e00-e5f9-11e9-9cac-f1c7bea05997.png">
</details>

Things that I already mapped on #6 and this PR address:
- [X] Fix the combinator for strings for some cases (for example, the `"V +"` is being tokenized as something like `[:punctuation, :variable, :whitespace, :operator])` and it should be a single unit
- [X] Fix the combinator for the interpolation characters, that as far as I can tell are not being tokenized at all
- [X] Add the string token to the binary combinator (<< >>)

I've been based all my changes on the "semi-official" [erlang/spec](https://github.com/erlang/spec), mostly the Grammar Appendix.