### PR TITLE
Simplify directive combinator (module attributes)

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -32,7 +32,7 @@ defmodule Makeup.Lexers.ErlangLexer do
 
   escape_octal = ascii_string([?0..?7], min: 1, max: 3)
 
-  escape_char = ascii_char([?b, ?d, ?e, ?f, ?n, ?r, ?s, ?t, ?v, ?', ?", ?\\])
+  escape_char = ascii_char([?\b, ?\d, ?\e, ?\f, ?\n, ?\r, ?\s, ?\t, ?\v, ?\', ?\", ?\\])
 
   escape_hex =
     choice([


### PR DESCRIPTION
<details>
<summary> Before </summary>
<img src="https://user-images.githubusercontent.com/14015177/66330070-0ab1a280-e906-11e9-9648-b5cc5aa14601.png"/>

</details>

<details>
<summary> After </summary>
<img src="https://user-images.githubusercontent.com/14015177/66330076-0dac9300-e906-11e9-8ef1-78763537b5f4.png"/>
</details>

Things that I already mapped on #6 and this PR address:
- [x] Fix the combinator for module attributes (e.g. -module, -import)

Changes that are unrelated to the scope of this PR and can be done in another one:
- Match on escaped characters instead of literal ones, e.g. `?\b` instead of `?b`:  9e89d1345fd3482b910e932942f44b089e0ffa8b

I've been based all my changes on the "semi-official" [erlang/spec](https://github.com/erlang/spec), mostly the Grammar Appendix.