### PR TITLE
Fix escaped characters in binary and quoted atoms

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -95,10 +95,20 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> optional(ascii_string([?a..?z, ?_, ?0..?9, ?A..?Z], min: 1))
     |> reduce({Enum, :join, []})
 
+  single_quote_escape = string("\\'")
+
+  quoted_atom_name_middle =
+    lookahead_not(string("'"))
+    |> choice([
+      single_quote_escape,
+      utf8_string([not: ?\n, not: ?', not: ?\\], min: 1),
+      escape
+    ])
+
   quoted_atom_name =
     string("'")
-    |> optional(utf8_string([not: ?\n, not: ?', not: ?\\], min: 1))
-    |> string("'")
+    |> repeat(quoted_atom_name_middle)
+    |> concat(string("'"))
 
   atom_name =
     choice([

--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -156,7 +156,8 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> ascii_char(to_charlist("~#+BPWXb-ginpswx"))
     |> token(:string_interpol)
 
-  erlang_string = string_like("\"", "\"", [string_interpol], :string)
+  escape_double_quote = string(~s/\\"/)
+  erlang_string = string_like(~s/"/, ~s/"/, [escape_double_quote, string_interpol], :string)
 
   # Combinators that highlight expressions surrounded by a pair of delimiters.
   punctuation =

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -152,6 +152,12 @@ defmodule ErlangLexerTokenizer do
       assert lex("'atom@atom'") == [{:string_symbol, %{}, "'atom@atom'"}]
       assert lex("'atom123atom'") == [{:string_symbol, %{}, "'atom123atom'"}]
     end
+    
+    test "are tokenized when quoted and have escaped characters" do
+      assert [{:string_symbol, %{}, ~s/'\\'escaped\\' quoted atom'/}] == lex(~s/'\\'escaped\\' quoted atom'/)
+      assert [{:string_symbol, %{}, ~s/'escaped \\b quote'/}] == lex(~s/'escaped \\b quote'/)
+      assert {:string_symbol, %{}, ~s/'\\'escaped\\' quoted atom/} not in lex(~s/'\\'invalid\\' quoted atom case/)
+    end
 
     test "does not tokenize invalid characters as atom (\\n, ', \\)" do
       assert {:string_symbol, %{}, "atom"} in lex("atom\n")

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -105,6 +105,17 @@ defmodule ErlangLexerTokenizer do
       assert {:string_interpol, %{}, "~p"} in lex(~s/"some text ~p"/)
       assert {:string_interpol, %{}, "~p"} in lex(~s/"multi line \n text ~p"/)
     end
+
+    test "tokenizes escape of double quotes correctly" do
+      assert [{:string, %{}, ~s/"escape \\"double quote\\""/}] == lex(~s/"escape \\"double quote\\""/)
+      assert [{:string, %{}, ~s/"\\"quote\\""/}] == lex(~s/"\\"quote\\""/)
+      assert {:string, %{}, ~s/"invalid string\\"/} not in lex(~s/"invalid string\\"/)
+    end
+    
+    test "tokenizes literal escaped characters correctly" do
+      assert [{:string, %{}, ~s/"\\b"/}] == lex(~s/"\\b"/)
+      assert [{:string, %{}, ~s/"\\\\b"/}] == lex(~s/"\\\\b"/)
+    end
   end
 
   describe "binary" do


### PR DESCRIPTION
<details>
<summary> Before </summary>
<img width="911" alt="Screenshot 2019-10-11 18 37 17" src="https://user-images.githubusercontent.com/14015177/66686599-5641b480-ec56-11e9-9f55-d08b79b1b23a.png">
</details>

<details>
<summary> After </summary>
<img width="878" alt="Screenshot 2019-10-11 18 37 30" src="https://user-images.githubusercontent.com/14015177/66686604-5b9eff00-ec56-11e9-8415-c7df79a84d89.png">
</details>

<details>
<summary> Tests </summary>
<img width="529" alt="Screenshot 2019-10-11 18 40 49" src="https://user-images.githubusercontent.com/14015177/66686683-a751a880-ec56-11e9-9c23-9eee92179e17.png">

</details>