### PR TITLE
Improvements for module highlight in qualified function calls, -spec definitions and records

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -178,6 +178,14 @@ defmodule Makeup.Lexers.ErlangLexer do
   syntax_operators =
     word_from_list(~W[+ - +? ++ = == -- * / < > /= =:= =/= =< >= ==? <- ! ? ?!], :operator)
 
+  record =
+    token(string("#"), :operator)
+    |> concat(atom)
+    |> choice([
+      token("{", :punctuation),
+      token(".", :punctuation)
+    ])
+
   # We need to match on the new line here as to not tokenize a function call as a module attribute.
   # Without the newline matching, the expression `a(X) - b(Y)` would tokenize
   # `b(Y)` as a module attribute definition instead of a function call.
@@ -204,6 +212,7 @@ defmodule Makeup.Lexers.ErlangLexer do
       whitespace,
       comment,
       erlang_string,
+      record,
       punctuation,
       # `tuple` might be unnecessary
       tuple,

--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -188,7 +188,7 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> optional(whitespace)
     |> concat(atom_name |> token(:name_attribute))
     |> optional(whitespace)
-    |> concat(token("(", :punctuation))
+    |> optional(token("(", :punctuation))
 
   # Tag the tokens with the language name.
   # This makes it easier to postprocess files with multiple languages.

--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -119,7 +119,7 @@ defmodule Makeup.Lexers.ErlangLexer do
   atom = token(atom_name, :string_symbol)
 
   namespace =
-    token(atom_name, :name_namespace)
+    token(atom_name, :name_class)
     |> concat(token(":", :punctuation))
 
   function =

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -314,4 +314,50 @@ defmodule ErlangLexerTokenizer do
         lex("-spec function_name(type(), type()) -> type().")
     end
   end
+
+  describe "record" do
+    test "tokenizes full record definitions correctly" do
+      assert [
+               {:operator, %{}, "#"},
+               {:string_symbol, %{}, "record"},
+               {:punctuation, %{}, "{"} | _
+             ] = lex("#record{attribute = Value}.")
+
+      assert [
+               {:operator, %{}, "#"},
+               {:string_symbol, %{}, "record"},
+               {:punctuation, %{}, "{"} | _
+             ] = lex("#record{attribute = Value, other_attribute = OtherValue}.")
+
+      assert [
+               {:operator, %{}, "#"},
+               {:string_symbol, %{}, "record"},
+               {:punctuation, %{}, "{"} | _
+             ] = lex("#record{}.")
+    end
+
+    test "tokenizes record attribute access correctly" do
+      assert [
+               {_, %{}, "RecordVariable"},
+               {:operator, %{}, "#"},
+               {:string_symbol, %{}, "record_name"},
+               {:punctuation, %{}, "."} | _
+             ] = lex("RecordVariable#record_name.attribute")
+    end
+
+    test "tokenizes the update of a record correctly" do
+      assert [
+               {_, %{}, "RecordVariable"},
+               {:operator, %{}, "#"},
+               {:string_symbol, %{}, "record_name"},
+               {:punctuation, %{}, "{"} | _
+             ] = lex("RecordVariable#record_name{attribute = Value")
+    end
+
+    test "does not tokenize invalid records" do
+      tokens = lex("#record(attribute = Value)")
+      assert {:operator, %{}, "#"} not in tokens
+      assert {:string_symbol, %{}, "record"} not in tokens
+    end
+  end
 end

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -24,7 +24,7 @@ defmodule ErlangLexerTokenizer do
 
   test "namespace" do
     assert lex("mod:") == [
-             {:name_namespace, %{}, "mod"},
+             {:name_class, %{}, "mod"},
              {:punctuation, %{}, ":"}
            ]
   end
@@ -52,7 +52,7 @@ defmodule ErlangLexerTokenizer do
 
   test "qualified function call" do
     assert lex("mod:f(1)") == [
-             {:name_namespace, %{}, "mod"},
+             {:name_class, %{}, "mod"},
              {:punctuation, %{}, ":"},
              {:name_function, %{}, "f"},
              {:punctuation, %{group_id: "group-1"}, "("},

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -308,5 +308,10 @@ defmodule ErlangLexerTokenizer do
       assert {:name_function, %{}, "b"} in lex("a(X) - b(Y)")
       assert {:name_attribute, %{}, "b"} not in lex("a(X) - b(Y)")
     end
+
+    test "handles -spec attributes" do
+      [{:punctuation, %{}, "-"}, {:name_attribute, %{}, "spec"} | _] =
+        lex("-spec function_name(type(), type()) -> type().")
+    end
   end
 end


### PR DESCRIPTION
Partially closes #12 

- [x] Highlight the module in a function call `module:function()`
- [x]  Improve the module attribute combinator to handle specs `-spec function(type()) -> type().`
- [x]  Add a combinator for record like syntax `#record{attribute = value}`

<details>
  <summary>Before</summary>
  <img width="891" alt="Screenshot 2019-10-15 12 02 17" src="https://user-images.githubusercontent.com/14015177/66843909-cfd1ef00-ef43-11e9-9a66-29913b728449.png">
</details>

<details>
  <summary>After</summary>
  <img width="866" alt="Screenshot 2019-10-15 12 01 52" src="https://user-images.githubusercontent.com/14015177/66843937-d82a2a00-ef43-11e9-8f4d-27e8e854a251.png">
</details>

<details>
  <summary>Tests</summary>
  <img width="456" alt="Screenshot 2019-10-15 12 05 01" src="https://user-images.githubusercontent.com/14015177/66844053-060f6e80-ef44-11e9-98ca-97d363b8bcf0.png">
</details>