### PR TITLE
Add combinator for function/arity syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+## Unreleased
+- Add combinator for function/arity syntax

--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -198,6 +198,11 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> optional(whitespace)
     |> optional(token("(", :punctuation))
 
+  function_arity =
+    atom
+    |> concat(token("/", :punctuation))
+    |> concat(number_integer)
+
   # Tag the tokens with the language name.
   # This makes it easier to postprocess files with multiple languages.
   @doc false
@@ -224,6 +229,7 @@ defmodule Makeup.Lexers.ErlangLexer do
       # Variables
       variable,
       namespace,
+      function_arity,
       function,
       atom,
       macro,

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -360,4 +360,21 @@ defmodule ErlangLexerTokenizer do
       assert {:string_symbol, %{}, "record"} not in tokens
     end
   end
+
+  describe "function_arity" do
+    test "is tokenized correctly for the syntax function_name/arity" do
+      assert [
+               {:string_symbol, %{}, "function_name"},
+               {:punctuation, %{}, "/"},
+               {:number_integer, %{}, "0"}
+             ] == lex("function_name/0")
+    end
+
+    test "is tokenized correctly when referenced with `fun function_name/arity`" do
+      tokens = lex("function_name/0")
+      assert {:string_symbol, %{}, "function_name"} in tokens
+      assert {:punctuation, %{}, "/"} in tokens
+      assert {:number_integer, %{}, "0"} in tokens
+    end
+  end
 end


### PR DESCRIPTION
Example: `-export([function_name/0])`

Fully closes #12 
- [x] Have a combinator for function names function/0?

<details>
<summary>Before</summary>
<img src="https://user-images.githubusercontent.com/14015177/66942198-e9943480-f01e-11e9-9951-048ba5c1e3df.png">
</details>

<details>
<summary>After</summary>
<img src="https://user-images.githubusercontent.com/14015177/66942176-dbdeaf00-f01e-11e9-9f1e-c87fba4a9a27.png">
</details>

<details>
<summary>Tests</summary>
<img width="524" alt="Screenshot 2019-10-16 14 11 04" src="https://user-images.githubusercontent.com/14015177/66942224-fadd4100-f01e-11e9-82c5-4de20b1b30dd.png">
</details>


#### Things done that are "unrelated" to this PR
- Add of a changelog (since now we have a published package in hex)