### PR TITLE
Switch to Application.compile_env/3

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -250,7 +250,7 @@ defmodule Makeup.Lexers.ErlangLexer do
   # meant to be used by end-users
   ##############################################################################
 
-  @inline Application.get_env(:makeup_erlang, :inline, false)
+  @inline Application.compile_env(:makeup_erlang, :inline, false)
 
   @impl Makeup.Lexer
   defparsec(

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule MakeupErlang.Mixfile do
     [
       app: :makeup_erlang,
       version: @version,
-      elixir: "~> 1.6",
+      elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Gets rid of this warning:

```
==> makeup_erlang
Compiling 3 files (.ex)
warning: Application.get_env/3 is discouraged in the module body, use Application.compile_env/3 instead
  lib/makeup/lexers/erlang_lexer.ex:250: Makeup.Lexers.ErlangLexer
```

This change requires the minimum-required Elixir version to be bumped to 1.10.  So, It's up to the maintainers to whether to accept this maybe significant change.