### PR TITLE
Highlight errors in shell examples correctly

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -255,6 +255,27 @@ defmodule Makeup.Lexers.ErlangLexer do
     |> string("> ")
     |> token(:generic_prompt, %{selectable: false})
 
+  # Error in shell
+  erl_shell_error =
+    token("\n", :whitespace)
+    |> concat(
+      string("* ")
+      |> utf8_string([not: ?\n], min: 1)
+      |> token(:generic_traceback)
+    )
+
+  erl_shell_multiline_error =
+    token("\n", :whitespace)
+    |> concat(
+      string("** ")
+      |> utf8_string([not: ?\n], min: 1)
+      |> repeat(
+        string("\n    ")
+        |> utf8_string([not: ?\n], min: 1)
+      )
+      |> token(:generic_traceback)
+    )
+
   # Tag the tokens with the language name.
   # This makes it easier to postprocess files with multiple languages.
   @doc false
@@ -266,6 +287,8 @@ defmodule Makeup.Lexers.ErlangLexer do
     choice(
       [
         erl_prompt,
+        erl_shell_error,
+        erl_shell_multiline_error,
         module_attribute,
         hashbang,
         whitespace,


### PR DESCRIPTION
It should be rare that a line starts with "* " or "** " unless it is an example of an error in the shell.

Question, is `:error` the correct token type for this?