### PR TITLE
Parse tabs correctly

### DIFF
--- a/lib/makeup/lexers/erlang_lexer.ex
+++ b/lib/makeup/lexers/erlang_lexer.ex
@@ -14,7 +14,7 @@ defmodule Makeup.Lexers.ErlangLexer do
   # Step #1: tokenize the input (into a list of tokens)
   ###################################################################
 
-  whitespace = ascii_string([?\s, ?\f, ?\n], min: 1) |> token(:whitespace)
+  whitespace = ascii_string([?\s, ?\f, ?\n, ?\t], min: 1) |> token(:whitespace)
 
   # This is the combinator that ensures that the lexer will never reject a file
   # because of invalid input syntax

--- a/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
+++ b/test/makeup/erlang_lexer/erlang_lexer_tokenizer_test.exs
@@ -6,6 +6,14 @@ defmodule ErlangLexerTokenizer do
     assert lex("") == []
   end
 
+  test "whitespace" do
+    assert lex(" ") == [{:whitespace, %{}, " "}]
+    assert lex("\n") == [{:whitespace, %{}, "\n"}]
+    assert lex("\t") == [{:whitespace, %{}, "\t"}]
+    assert lex("\f") == [{:whitespace, %{}, "\f"}]
+    assert lex("\s") == [{:whitespace, %{}, "\s"}]
+  end
+
   test "character" do
     assert lex("$a") == [{:string_char, %{}, "$a"}]
     assert lex("$\\ ") == [{:string_char, %{}, "$\\ "}]


### PR DESCRIPTION
I don't support tabs and certainly not mixed with spaces but this should not produce errors.

Note: not sure what `\s` is supposed to be matching? worth double checking whether it's really needed.

Fixes #28 